### PR TITLE
Overload createConstructionSite with RoomPosition parameter.

### DIFF
--- a/dist/game/utils.d.ts
+++ b/dist/game/utils.d.ts
@@ -121,6 +121,20 @@ declare module "game/utils" {
     error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
   };
 
+  /**
+   * Create new ConstructionSite at the specified location.
+   * @param pos The X,Y position.
+   * @param structurePrototype One of the following constants: StuctureExtension, StructureTower
+   * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+   */
+  export function createConstructionSite(
+    pos: RoomPosition,
+    structureType: _Constructor<BuildableStructure>
+  ): {
+    object?: ConstructionSite;
+    error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
+  };
+
   export interface HeapStatistics {
     total_heap_size: number;
     total_heap_size_executable: number;

--- a/dist/test/screeps-arena-tests.ts
+++ b/dist/test/screeps-arena-tests.ts
@@ -109,5 +109,11 @@ export function loop(): void {
   // TODO: verify all buildable structure types
   // TODO: cSites .structure property.
 
+  // overload of createConstructionSite
+  createConstructionSite({ x: 10, y: 10 }, StructureRampart);
+  if (myTower) {
+    createConstructionSite(myTower, StructureRampart);
+  }
+
   // TODO: test utils findXXX methods, theese methods are used by other metods.
 }


### PR DESCRIPTION
The docs say to use a `RoomPosition` object with `createConstructionSite`. That that worked in the demo. I didn't try the separated `x`, `y` version, so this may or may not need to be a replacement.