### PR TITLE
Add AreaEffect prototype and adjust arena/constants

### DIFF
--- a/dist/arena/constants.d.ts
+++ b/dist/arena/constants.d.ts
@@ -1,9 +1,17 @@
 declare module "arena/constants" {
-  export const RESOURCE_SCORE = "score";
-  export const RESOURCE_SCORE_X = "score_x";
-  export const RESOURCE_SCORE_Y = "score_y";
-  export const RESOURCE_SCORE_Z = "score_z";
-  export const EFFECT_FREEZE = "freeze";
-  export const EFFECT_HEAL = "heal";
-  export const EFFECT_DAMAGE = "damage";
+  export type RESOURCE_SCORE = "score";
+  export type RESOURCE_SCORE_X = "score_x";
+  export type RESOURCE_SCORE_Y = "score_y";
+  export type RESOURCE_SCORE_Z = "score_z";
+  export type EFFECT_FREEZE = "freeze";
+  export type EFFECT_HEAL = "heal";
+  export type EFFECT_DAMAGE = "damage";
+
+  export const RESOURCE_SCORE: RESOURCE_SCORE;
+  export const RESOURCE_SCORE_X: RESOURCE_SCORE_X;
+  export const RESOURCE_SCORE_Y: RESOURCE_SCORE_Y;
+  export const RESOURCE_SCORE_Z: RESOURCE_SCORE_Z;
+  export const EFFECT_FREEZE: EFFECT_FREEZE;
+  export const EFFECT_HEAL: EFFECT_HEAL;
+  export const EFFECT_DAMAGE: EFFECT_DAMAGE;
 }

--- a/dist/arena/constants.d.ts
+++ b/dist/arena/constants.d.ts
@@ -7,6 +7,8 @@ declare module "arena/constants" {
   export type EFFECT_HEAL = "heal";
   export type EFFECT_DAMAGE = "damage";
 
+  export type ArenaResourceConstant = RESOURCE_SCORE | RESOURCE_SCORE_X | RESOURCE_SCORE_Y | RESOURCE_SCORE_Z;
+
   export const RESOURCE_SCORE: RESOURCE_SCORE;
   export const RESOURCE_SCORE_X: RESOURCE_SCORE_X;
   export const RESOURCE_SCORE_Y: RESOURCE_SCORE_Y;

--- a/dist/arena/prototypes/area-effect.d.ts
+++ b/dist/arena/prototypes/area-effect.d.ts
@@ -1,0 +1,11 @@
+declare module "arena/prototypes" {
+    import { GameObject, _Constructor } from "game/prototypes";
+    export interface AreaEffect extends GameObject {
+      /**
+       * The type of the effect this has on creep. "freeze" or "damage".
+       */
+      effect: string;
+    }
+
+    export const AreaEffect: _Constructor<AreaEffect>;
+  }

--- a/dist/arena/prototypes/index.d.ts
+++ b/dist/arena/prototypes/index.d.ts
@@ -1,3 +1,4 @@
 /// <reference path="flag.d.ts" />
 /// <reference path="body-part.d.ts" />
 /// <reference path="score-collector.d.ts" />
+/// <reference path="area-effect.d.ts" />

--- a/dist/arena/prototypes/score-collector.d.ts
+++ b/dist/arena/prototypes/score-collector.d.ts
@@ -1,8 +1,6 @@
 declare module "arena/prototypes" {
-  export type STRUCTURE_SCORE_COLLECTOR = "constructedWall";
-  import { OwnedStructure, _Constructor } from "game/prototypes";
-  export interface ScoreCollector
-    extends OwnedStructure<STRUCTURE_SCORE_COLLECTOR> {
+  import { GameObject, _Constructor } from "game/prototypes";
+  export interface ScoreCollector extends GameObject {
     /**
      * The type of the resource this collector accepts.
      */

--- a/dist/game/constants.d.ts
+++ b/dist/game/constants.d.ts
@@ -1,5 +1,5 @@
 declare module "game/constants" {
-  import type { RESOURCE_SCORE, RESOURCE_SCORE_X, RESOURCE_SCORE_Y, RESOURCE_SCORE_Z } from "arena";
+  import type { ArenaResourceConstant } from "arena";
   import type {
     Creep,
     STRUCTURE_CONTAINER,
@@ -184,7 +184,7 @@ declare module "game/constants" {
   export type RESOURCE_ENERGY = "energy";
   export const RESOURCE_ENERGY: RESOURCE_ENERGY;
 
-  export type ResourceConstant = RESOURCE_ENERGY | RESOURCE_SCORE | RESOURCE_SCORE_X | RESOURCE_SCORE_Y | RESOURCE_SCORE_Z;
+  export type ResourceConstant = RESOURCE_ENERGY | ArenaResourceConstant;
 
   export type AnyCreep = Creep; /* | PowerCreep;*/
 

--- a/dist/game/constants.d.ts
+++ b/dist/game/constants.d.ts
@@ -1,6 +1,6 @@
 declare module "game/constants" {
-  import { RESOURCE_SCORE } from "arena";
-  import {
+  import type { RESOURCE_SCORE, RESOURCE_SCORE_X, RESOURCE_SCORE_Y, RESOURCE_SCORE_Z } from "arena";
+  import type {
     Creep,
     STRUCTURE_CONTAINER,
     STRUCTURE_EXTENSION,
@@ -181,9 +181,10 @@ declare module "game/constants" {
   export const TOWER_RANGE: number;
   export const TOWER_COOLDOWN: number;
 
-  export const RESOURCE_ENERGY: "energy";
+  export type RESOURCE_ENERGY = "energy";
+  export const RESOURCE_ENERGY: RESOURCE_ENERGY;
 
-  export type ResourceConstant = typeof RESOURCE_ENERGY | typeof RESOURCE_SCORE;
+  export type ResourceConstant = RESOURCE_ENERGY | RESOURCE_SCORE | RESOURCE_SCORE_X | RESOURCE_SCORE_Y | RESOURCE_SCORE_Z;
 
   export type AnyCreep = Creep; /* | PowerCreep;*/
 

--- a/dist/test/screeps-arena-tests.ts
+++ b/dist/test/screeps-arena-tests.ts
@@ -5,7 +5,7 @@ import {
   StructureRampart,
   StructureTower
 } from "game/prototypes";
-import { Flag, RESOURCE_SCORE, ScoreCollector } from "arena";
+import { Flag, RESOURCE_SCORE, ScoreCollector, AreaEffect } from "arena";
 import { constants, pathFinder, prototypes, utils } from "game";
 import {
   createConstructionSite,
@@ -17,6 +17,7 @@ import {
 } from "game/utils";
 import { CostMatrix } from "game/path-finder";
 import { RESOURCE_ENERGY } from "game/constants";
+import { EFFECT_DAMAGE, EFFECT_FREEZE, RESOURCE_SCORE_X, RESOURCE_SCORE_Y, RESOURCE_SCORE_Z } from "arena/constants";
 
 export function loop(): void {
   // console.log(`The time is ${getTime()}`);
@@ -101,7 +102,19 @@ export function loop(): void {
   if (scoreTestCreep && scoreCollector) {
     const scoreStored = scoreTestCreep.store[RESOURCE_SCORE];
     scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE);
+
+    // $ExpectType boolean
+    const inControl = scoreCollector.my;
+
+    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_X);
+    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_Y);
+    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_Z);
   }
+
+  // $ExpectType AreaEffect[]
+  const areaEffects = utils.getObjectsByPrototype(AreaEffect);
+  const freezeEffects = areaEffects.filter(x => x.effect === EFFECT_FREEZE);
+  const damageEffects = areaEffects.filter(x => x.effect === EFFECT_DAMAGE);
 
   // build a rampart
   createConstructionSite(10, 10, StructureRampart);


### PR DESCRIPTION
I added the `AreaEffect` which was needed for Collect and Control advanced (to avoid the damage effects). I also adjusted the `arena/constants` to be split types/const like the other constants.

Also, adjusted ScoreCollector to extend GameObject like in the docs. Just because it has a `my` property, I don't think it should derive from owned because the control flips based on score.