### PR TITLE
Added index.d.ts in root directory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="dist/index.d.ts" />

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "screepers/typed-screeps-arena",
   "types": "./dist/**/*.d.ts",
   "files": [
-    "dist/**/*.d.ts"
+    "dist/**/*.d.ts",
+	"index.d.ts"
   ],
   "scripts": {
     "compile:dtslint": "node ./build/concat.js && node ./build/prependHeader.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/**/*.d.ts",
   "files": [
     "dist/**/*.d.ts",
-	"index.d.ts"
+    "index.d.ts"
   ],
   "scripts": {
     "compile:dtslint": "node ./build/concat.js && node ./build/prependHeader.js",


### PR DESCRIPTION
Fix for "rpt2: options error TS6053: File '......./node_modules/@types/screeps-arena/index.d.ts' not found."