### PR TITLE
Remove invalid createConstructionSite

### DIFF
--- a/dist/game/index.d.ts
+++ b/dist/game/index.d.ts
@@ -48,13 +48,4 @@ declare module "game" {
      */
     cpuTimeLimitFirstTick: number;
   };
-
-  export function createConstructionSite(
-    x: number,
-    y: number,
-    structurePrototype: string /*STRUCTURE_PROTOTYPES*/
-  ): {
-    object?: Structure;
-    error?: ERR_BUSY | ERR_INVALID_ARGS | ERR_NOT_ENOUGH_ENERGY;
-  };
 }


### PR DESCRIPTION
this removes the invalid type definition for createConstructionSite, leaving the correct one from dist/game/utils.d.ts

fixes #23 