### PR TITLE
change resourceType definition

### DIFF
--- a/dist/arena/season_beta/collect_and_control/basic/prototypes/score-collector.d.ts
+++ b/dist/arena/season_beta/collect_and_control/basic/prototypes/score-collector.d.ts
@@ -1,10 +1,12 @@
+import { ResourceConstant } from "game/constants";
+import { GameObject, _Constructor } from "game/prototypes";
+
 declare module "arena/season_beta/collect_and_control/basic/prototypes" {
-  import { GameObject, _Constructor } from "game/prototypes";
   export interface ScoreCollector extends GameObject {
     /**
      * The type of the resource this collector accepts.
      */
-    resourceType: string;
+    resourceType: ResourceConstant;
     /**
      * Whether you have control over this collector.
      */

--- a/dist/game/constants.d.ts
+++ b/dist/game/constants.d.ts
@@ -1,6 +1,10 @@
 declare module "game/constants" {
   import type { RESOURCE_SCORE } from "arena/season_beta/collect_and_control/basic/constants";
-  import type { RESOURCE_SCORE_X, RESOURCE_SCORE_Y, RESOURCE_SCORE_Z } from "arena/season_beta/collect_and_control/advanced/constants";
+  import type {
+    RESOURCE_SCORE_X,
+    RESOURCE_SCORE_Y,
+    RESOURCE_SCORE_Z,
+  } from "arena/season_beta/collect_and_control/advanced/constants";
   import type {
     Creep,
     STRUCTURE_CONTAINER,

--- a/dist/test/screeps-arena-tests.ts
+++ b/dist/test/screeps-arena-tests.ts
@@ -18,9 +18,7 @@ import {
 } from "game/utils";
 import { CostMatrix } from "game/path-finder";
 import { RESOURCE_ENERGY } from "game/constants";
-import {
-  Flag,
-} from "arena/season_beta/capture_the_flag/basic/prototypes";
+import { Flag } from "arena/season_beta/capture_the_flag/basic/prototypes";
 import {
   ScoreCollector,
   AreaEffect,
@@ -133,15 +131,20 @@ export function loop(): void {
   const scoreTestCreep = getObjectsByPrototype(Creep).find((i) => i.my);
   const scoreCollector = getObjectsByPrototype(ScoreCollector)[0];
   if (scoreTestCreep && scoreCollector) {
-    const scoreStored = scoreTestCreep.store[RESOURCE_SCORE];
-    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE);
-
     // $ExpectType boolean
     const inControl = scoreCollector.my;
 
-    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_X);
-    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_Y);
-    scoreTestCreep.transfer(scoreCollector, RESOURCE_SCORE_Z);
+    const scoreTypes = [
+      RESOURCE_SCORE,
+      RESOURCE_SCORE_X,
+      RESOURCE_SCORE_Y,
+      RESOURCE_SCORE_Z,
+      scoreCollector.resourceType,
+    ];
+    for (const scoreType of scoreTypes) {
+      const scoreStored = scoreTestCreep.store[scoreType];
+      scoreTestCreep.transfer(scoreCollector, scoreType);
+    }
   }
 
   // $ExpectType AreaEffect[]


### PR DESCRIPTION
it is required for this code(I will use in advanced).

```
const sc = getObjectsByPrototype(ScoreCollector);
const creep = getObjectsByPrototype(Creep).find(c => c.my);
creep.transfer(sc, sc.resourceType); // <-- if old definitions, type mismatch at here
```