### PR TITLE
Rename RoomPosition to Position

### DIFF
--- a/dist/arena/season_beta/capture_the_flag/basic/prototypes/body-part.d.ts
+++ b/dist/arena/season_beta/capture_the_flag/basic/prototypes/body-part.d.ts
@@ -2,6 +2,7 @@ declare module "arena/season_beta/capture_the_flag/basic/prototypes" {
   import { GameObject, _Constructor, _ConstructorById } from "game/prototypes";
   import { BodyPartConstant } from "game/constants";
 
+  /** A separate part of creep body */
   export interface BodyPart extends GameObject {
     readonly prototype: BodyPart;
     /**
@@ -13,8 +14,10 @@ declare module "arena/season_beta/capture_the_flag/basic/prototypes" {
      */
     ticksToDecay: number;
   }
+
   interface BodyPartConstructor
     extends _Constructor<BodyPart>,
       _ConstructorById<BodyPart> {}
+
   export const BodyPart: BodyPartConstructor;
 }

--- a/dist/arena/season_beta/capture_the_flag/basic/prototypes/flag.d.ts
+++ b/dist/arena/season_beta/capture_the_flag/basic/prototypes/flag.d.ts
@@ -1,16 +1,19 @@
 declare module "arena/season_beta/capture_the_flag/basic/prototypes" {
   import { GameObject, _Constructor, _ConstructorById } from "game/prototypes";
+
+  /** A flag is a key game object for this arena. Capture all flags to win the game */
   export interface Flag extends GameObject {
     readonly prototype: Flag;
     /**
      * Equals to true or false if the flag is owned.
      * Returns undefined if it is neutral.
      */
-    my: boolean | undefined;
+    my?: boolean;
   }
 
   interface FlagConstructor
     extends _Constructor<Flag>,
       _ConstructorById<Flag> {}
+
   export const Flag: FlagConstructor;
 }

--- a/dist/arena/season_beta/collect_and_control/basic/prototypes/area-effect.d.ts
+++ b/dist/arena/season_beta/collect_and_control/basic/prototypes/area-effect.d.ts
@@ -1,14 +1,26 @@
 declare module "arena/season_beta/collect_and_control/basic/prototypes" {
   import { GameObject, _Constructor } from "game/prototypes";
+  import {
+    EFFECT_DAMAGE,
+    EFFECT_FREEZE,
+    EFFECT_HEAL,
+  } from "arena/season_beta/collect_and_control/basic/constants";
+
+  type AreaEffectType =
+    | typeof EFFECT_FREEZE
+    | typeof EFFECT_DAMAGE
+    | typeof EFFECT_HEAL;
+
+  /** An object that applies an effect of the specified type to all creeps at the same time */
   export interface AreaEffect extends GameObject {
     /**
      * The type of the effect this has on creep. "freeze" or "damage".
      */
-    effect: string;
+    effect: AreaEffectType;
     /**
      * The amount of game ticks when this effect will disappear. (undocumented)
      */
-    ticksToDecay: number | undefined;
+    ticksToDecay?: number;
   }
 
   export const AreaEffect: _Constructor<AreaEffect>;

--- a/dist/arena/season_beta/collect_and_control/basic/prototypes/score-collector.d.ts
+++ b/dist/arena/season_beta/collect_and_control/basic/prototypes/score-collector.d.ts
@@ -1,7 +1,8 @@
-import { ResourceConstant } from "game/constants";
-import { GameObject, _Constructor } from "game/prototypes";
-
 declare module "arena/season_beta/collect_and_control/basic/prototypes" {
+  import { ResourceConstant } from "game/constants";
+  import { GameObject, _Constructor } from "game/prototypes";
+
+  /** Key game object for this arena. Transfer the corresponding resource to the collector to win the game */
   export interface ScoreCollector extends GameObject {
     /**
      * The type of the resource this collector accepts.

--- a/dist/game/constants.d.ts
+++ b/dist/game/constants.d.ts
@@ -64,6 +64,8 @@ declare module "game/constants" {
     | LEFT
     | TOP_LEFT;
 
+  export type TerrainConstant = TERRAIN_WALL | TERRAIN_SWAMP | TERRAIN_PLAIN;
+
   export type TOP = 1;
   export type TOP_RIGHT = 2;
   export type RIGHT = 3;
@@ -83,23 +85,6 @@ declare module "game/constants" {
   export const TOP_LEFT: TOP_LEFT;
 
   // Return Codes
-  export type ScreepsReturnCode =
-    | OK
-    | ERR_NOT_OWNER
-    | ERR_NO_PATH
-    | ERR_BUSY
-    | ERR_NAME_EXISTS
-    | ERR_NOT_FOUND
-    | ERR_NOT_ENOUGH_RESOURCES
-    | ERR_NOT_ENOUGH_ENERGY
-    | ERR_INVALID_TARGET
-    | ERR_FULL
-    | ERR_NOT_IN_RANGE
-    | ERR_INVALID_ARGS
-    | ERR_TIRED
-    | ERR_NO_BODYPART
-    | ERR_NOT_ENOUGH_EXTENSIONS;
-
   export type OK = 0;
   export type ERR_NOT_OWNER = -1;
   export type ERR_NO_PATH = -2;
@@ -115,25 +100,6 @@ declare module "game/constants" {
   export type ERR_TIRED = -11;
   export type ERR_NO_BODYPART = -12;
   export type ERR_NOT_ENOUGH_EXTENSIONS = -6;
-
-  export type CreepActionReturnCode =
-    | OK
-    | ERR_NOT_OWNER
-    | ERR_BUSY
-    | ERR_INVALID_TARGET
-    | ERR_NOT_IN_RANGE
-    | ERR_NO_BODYPART
-    | ERR_TIRED;
-
-  export type CreepMoveReturnCode =
-    | OK
-    | ERR_NOT_OWNER
-    | ERR_BUSY
-    | ERR_TIRED
-    | ERR_NO_BODYPART;
-
-  export const CARRY_CAPACITY: number;
-  export const CREEP_SPAWN_TIME: number;
 
   export const ERR_BUSY: ERR_BUSY;
   export const ERR_FULL: ERR_FULL;
@@ -151,13 +117,124 @@ declare module "game/constants" {
   export const ERR_TIRED: ERR_TIRED;
   export const OK: OK;
 
+  export type CreepAttackResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepBuildResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_NOT_ENOUGH_RESOURCES
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepDropResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_INVALID_ARGS
+    | ERR_NOT_ENOUGH_RESOURCES;
+
+  export type CreepHarvestResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_INVALID_TARGET
+    | ERR_NOT_ENOUGH_RESOURCES
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepHealResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepMoveResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_TIRED
+    | ERR_INVALID_ARGS;
+
+  export type CreepPickupResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_INVALID_TARGET
+    | ERR_FULL
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepPullResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_TIRED
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepRangedAttackResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepRangedHealResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE;
+
+  export type CreepRangedMassAttackResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_NO_BODYPART;
+
+  export type CreepTransferResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_INVALID_ARGS
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE
+    | ERR_FULL
+    | ERR_NOT_ENOUGH_RESOURCES;
+
+  export type CreepWithdrawResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_INVALID_ARGS
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE
+    | ERR_FULL
+    | ERR_NOT_ENOUGH_RESOURCES;
+
+  export type TowerAttackResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_TIRED
+    | ERR_INVALID_TARGET
+    | ERR_NOT_ENOUGH_ENERGY;
+
+  export type TowerHealResult =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_TIRED
+    | ERR_INVALID_TARGET
+    | ERR_NOT_ENOUGH_ENERGY;
+
+  export const CARRY_CAPACITY: number;
+  export const CREEP_SPAWN_TIME: number;
+
   export type OBSTACLE_OBJECT_TYPES =
-    | AnyCreep
+    | Creep
     | STRUCTURE_TOWER
     | STRUCTURE_WALL
     | STRUCTURE_SPAWN
     | STRUCTURE_EXTENSION;
-  // | STRUCTURE_LINK
 
   export const OBSTACLE_OBJECT_TYPES: OBSTACLE_OBJECT_TYPES;
   export const RANGED_ATTACK_DISTANCE_RATE: any[];
@@ -192,8 +269,6 @@ declare module "game/constants" {
   export const RESOURCE_ENERGY: RESOURCE_ENERGY;
 
   export type ResourceConstant = RESOURCE_ENERGY | ArenaResourceConstant;
-
-  export type AnyCreep = Creep; /* | PowerCreep;*/
 
   export const BODYPART_COST: { [index in BodyPartConstant]: number };
   export const BODYPART_HITS: number;

--- a/dist/game/path-finder.d.ts
+++ b/dist/game/path-finder.d.ts
@@ -1,28 +1,24 @@
 declare module "game/path-finder" {
-  import { GameObject, RoomPosition, _Constructor } from "game/prototypes";
+  import { GameObject, Position, _Constructor } from "game/prototypes";
+
+  export type Goal = Position | { pos: Position; range: number };
+
   export function searchPath(
-    origin: RoomPosition,
-    goal:
-      | RoomPosition
-      | { pos: RoomPosition; range: number }
-      | Array<RoomPosition | { pos: RoomPosition; range: number }>,
-    opts?: FindPathOpts
-  ): FindPathResult;
+    origin: Position,
+    goal: Goal | Goal[],
+    options?: SearchPathOptions
+  ): SearchPathResult;
 
   export interface CostMatrix {
-    // /**
-    //  * Creates a new CostMatrix containing 0's for all positions.
-    //  */
-    // new (): CostMatrix;
-
     _bits: Uint8Array;
+
     /**
      * Set the cost of a position in this CostMatrix.
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param cost Cost of this position. Must be a whole number. A cost of 0 will use the terrain cost for that tile. A cost greater than or equal to 255 will be treated as unwalkable.
      */
-    set(x: number, y: number, cost: number): undefined;
+    set(x: number, y: number, cost: number): void;
 
     /**
      * Get the cost of a position in this CostMatrix.
@@ -30,20 +26,11 @@ declare module "game/path-finder" {
      * @param y Y position in the room.
      */
     get(x: number, y: number): number;
+
     /**
      * Copy this CostMatrix into a new CostMatrix with the same data.
      */
     clone(): CostMatrix;
-    /**
-     * Returns a compact representation of this CostMatrix which can be stored via JSON.stringify.
-     */
-    serialize(): number[];
-
-    /**
-     * Static method which deserializes a new CostMatrix using the return value of serialize.
-     * @param val Whatever serialize returned
-     */
-    deserialize(val: number[]): CostMatrix;
   }
 
   interface CostMatrixConstructor
@@ -52,148 +39,56 @@ declare module "game/path-finder" {
 
   export const CostMatrix: CostMatrixConstructor;
 
-  export interface FindPathOpts {
-    // // /**
-    // //  * Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default
-    // //  * value is false.
-    // //  */
-    // // ignoreCreeps?: boolean;
+  export interface SearchPathResult {
+    /** The path found as an array of objects containing x and y properties */
+    path: Position[];
 
-    // // /**
-    // //  * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when
-    // //  * you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square,
-    // //  * it automatically attacks the structure. The default value is false.
-    // //  */
-    // // ignoreDestructibleStructures?: boolean;
+    /** Total number of operations performed before this path was calculated */
+    ops: number;
 
-    // // /**
-    // //  * Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the
-    // //  * new PathFinder is enabled.
-    // //  */
-    // // ignoreRoads?: boolean;
+    /** The total cost of the path as derived from plainCost, swampCost, and given CostMatrix instance */
+    cost: number;
 
-    // // /**
-    // //  * You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName
-    // //  * and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback,
-    // //  * it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
-    // //  *
-    // //  * @param roomName The name of the room.
-    // //  * @param costMatrix The current CostMatrix
-    // //  * @returns The new CostMatrix to use
-    // //  */
-    // // costCallback?(roomName: string, costMatrix: CostMatrix): void | CostMatrix;
+    /** If the pathfinder fails to find a complete path, this will be true */
+    incomplete: boolean;
+  }
 
-    // // /**
-    // //  * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option
-    // //  * cannot be used when the new PathFinder is enabled (use costCallback option instead).
-    // //  */
-    // // ignore?: any[] | RoomPosition[];
+  export interface SearchPathOptions {
+    /** Custom navigation cost data */
+    costMatrix?: CostMatrix;
 
-    /**
-     * (Instead of searching for a path to the goals this will search for a path away from the goals.
-     * The cheapest path that is out of range of every goal will be returned.
-     * The default is false)
-     */
-    flee?: boolean;
-
-    /**
-     * The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
-     * The default value is 2000.
-     */
-    maxOps?: number;
-
-    /**
-     * (The maximum allowed cost of the path returned. The default is Infinity.)
-     */
-    maxCost?: number;
-
-    /**
-     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying
-     * A* algorithm mechanics! The default value is 1.2.
-     */
-    heuristicWeight?: number;
-
-    // // /**
-    // //  * If true, the result path will be serialized using Room.serializePath. The default is false.
-    // //  */
-    // // serialize?: boolean;
-
-    /**
-     * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
-     */
-    range?: number;
-
-    /**
-     * Cost for walking on plain positions. The default is 1.
-     */
+    /** Cost for walking on plain positions. The default is 2 */
     plainCost?: number;
 
-    /**
-     * Cost for walking on swamp positions. The default is 5.
-     */
+    /** Cost for walking on swamp positions. The default is 10 */
     swampCost?: number;
 
     /**
-     * CostMatrix (Container for custom navigation cost data)
+     * Instead of searching for a path to the goals this will search for a path away from the goals.
+     * The cheapest path that is out of range of every goal will be returned.
+     * The default is false
      */
-    costMatrix?: CostMatrix;
+    flee?: boolean;
+
+    /** The maximum allowed pathfinding operations. The default value is 50000 */
+    maxOps?: number;
+
+    /** The maximum allowed cost of the path returned. The default is Infinity */
+    maxCost?: number;
+
+    /** Weight from 1 to 9 to apply to the heuristic in the A* formula F = G + weight * H. The default value is 1.2 */
+    heuristicWeight?: number;
 
     /**
-     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search
+     * An array of the room's objects or Position objects which should be treated as obstacles during the search
      */
-    ignore?: RoomPosition[];
+    ignore?: Position[];
   }
 
-  export interface MoveToOpts extends FindPathOpts {
-    // // /**
-    // //  * This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly
-    // //  * slower creep reaction behavior. The path is stored into the creep's memory to the `_move` property. The `reusePath` value defines
-    // //  * the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease
-    // //  * to make the movement more consistent. Set to 0 if you want to disable path reusing.
-    // //  */
-    // // reusePath?: number;
-    // // /**
-    // //  * If `reusePath` is enabled and this option is set to true, the path will be stored in memory in the short serialized form using
-    // //  * `Room.serializePath`. The default value is true.
-    // //  */
-    // // serializeMemory?: boolean;
-    // // /**
-    // //  * If this option is set to true, `moveTo` method will return `ERR_NOT_FOUND` if there is no memorized path to reuse. This can
-    // //  * significantly save CPU time in some cases. The default value is false.
-    // //  */
-    // // noPathFinding?: boolean;
-    // // /**
-    // //  * Draw a line along the creep’s path using `RoomVisual.poly`. You can provide either an empty object or custom style parameters.
-    // //  */
-    // // visualizePathStyle?: PolyStyle;
-  }
-
-  export interface FindPathResult {
+  export interface FindPathOptions extends SearchPathOptions {
     /**
-     * The path found as an array of objects containing x and y properties
+     * An array of the room's objects which should be treated as obstacles during the search
      */
-    path: PathStep[];
-
-    /**
-     * Total number of operations performed before this path was calculated
-     */
-    ops: number;
-
-    /**
-     * The total cost of the path as derived from `plainCost`, `swampCost`, and given `CostMatrix` instance
-     */
-    cost: number;
-
-    /**
-     * If the pathfinder fails to find a complete path, this will be true
-     */
-    incomplete: boolean;
-  }
-  export interface PathStep {
-    x: number;
-    // dx: number;
-    y: number;
-    // dy: number;
-    // direction: DirectionConstant;
+    ignore?: GameObject[];
   }
 }

--- a/dist/game/prototypes/construction-site.d.ts
+++ b/dist/game/prototypes/construction-site.d.ts
@@ -1,15 +1,13 @@
 declare module "game/prototypes" {
-  import {
-    BuildableStructure,
-    ERR_NOT_OWNER,
-    OK,
-    STRUCTURE_PROTOTYPES,
-  } from "game/constants";
+  import { BuildableStructure } from "game/constants";
+
+  /**
+   * A site of a structure which is currently under construction
+   */
   export interface ConstructionSite<
     T extends BuildableStructure = BuildableStructure
   > extends GameObject {
     readonly prototype: ConstructionSite<T>;
-
     /**
      * The current construction progress.
      */
@@ -18,24 +16,23 @@ declare module "game/prototypes" {
      * The total construction progress needed for the structure to be built.
      */
     progressTotal: number;
-
     /**
      * One of the STRUCTURE_PROTOTYPES entries
      */
     structurePrototypeName: string;
-
     /**
      * The structure that was built (when the construction site is completed)
      * You can check what structure is being constructed using the instanceof operator:
      */
     structure: T;
-
     /**
      * Whether it is your construction site.
      */
     my: boolean;
-
-    remove(): ERR_NOT_OWNER | OK;
+    /**
+     * Remove this construction site
+     */
+    remove(): void;
   }
 
   interface ConstructionSiteConstructor

--- a/dist/game/prototypes/creep.d.ts
+++ b/dist/game/prototypes/creep.d.ts
@@ -1,25 +1,28 @@
 declare module "game/prototypes" {
   import { ScoreCollector } from "arena/season_beta/collect_and_control/basic/prototypes";
   import {
-    AnyCreep,
     BodyPartConstant,
-    CreepActionReturnCode,
-    CreepMoveReturnCode,
+    CreepAttackResult,
+    CreepBuildResult,
+    CreepDropResult,
+    CreepHarvestResult,
+    CreepHealResult,
+    CreepMoveResult,
+    CreepPickupResult,
+    CreepPullResult,
+    CreepRangedAttackResult,
+    CreepRangedHealResult,
+    CreepRangedMassAttackResult,
+    CreepTransferResult,
+    CreepWithdrawResult,
     DirectionConstant,
-    ERR_BUSY,
-    ERR_FULL,
-    ERR_INVALID_TARGET,
-    ERR_NOT_ENOUGH_RESOURCES,
-    ERR_NOT_FOUND,
-    ERR_NOT_IN_RANGE,
-    ERR_NOT_OWNER,
-    ERR_NO_BODYPART,
-    ERR_NO_PATH,
-    OK,
     ResourceConstant,
-    ScreepsReturnCode,
   } from "game/constants";
-  import { MoveToOpts } from "game/path-finder";
+  import { FindPathOptions } from "game/path-finder";
+
+  /**
+   * Creeps are units that can move, harvest energy, construct structures, attack another creeps, and perform other actions.
+   */
   export interface Creep extends GameObject {
     readonly prototype: Creep;
     /**
@@ -45,55 +48,56 @@ declare module "game/prototypes" {
      */
     body: Array<{ type: BodyPartConstant; hits: number }>;
     /**
+     * Whether this creep is spawning or not. (undocumented)
+     */
+    spawning: boolean;
+    /**
      * A Store object that contains cargo of this creep.
      */
     store: Store<ResourceConstant>;
     /**
      * Move the creep one square in the specified direction. direction must be one of the following constants:
      */
-    move(direction: DirectionConstant): CreepMoveReturnCode;
+    move(direction: DirectionConstant): CreepMoveResult;
     /**
      * Find the optimal path to the target within the same room and move to it.
      * A shorthand to consequent calls of findPathTo() and move() methods.
      * @param target target can be any object containing x and y properties.
      * @param opts opts is an optional object containing additional options. See /game/utils::findPath for details.
      */
-    moveTo(
-      target: RoomPosition,
-      opts?: MoveToOpts
-    ): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET | undefined;
+    moveTo(target: Position, opts?: FindPathOptions): CreepMoveResult;
     /**
      * A ranged attack against another creep or structure. Requires the RANGED_ATTACK body part.
      * The target has to be within 3 squares range of the creep.
      */
-    rangedAttack(target: AnyCreep | Structure): CreepActionReturnCode;
+    rangedAttack(target: Creep | Structure): CreepRangedAttackResult;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range.
      * Requires the RANGED_ATTACK body part.
      * The attack power depends on the range of each target.
      * Friendly units are not affected.
      */
-    rangedMassAttack(): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NO_BODYPART;
+    rangedMassAttack(): CreepRangedMassAttackResult;
     /**
      * Attack another creep or structure in a short-ranged attack.
      * Requires the ATTACK body part.
      * The target has to be at an adjacent square to the creep.
      */
-    attack(target: AnyCreep | Structure): CreepActionReturnCode;
+    attack(target: Creep | Structure): CreepAttackResult;
     /**
      * Heal self or another creep.
      * It will restore the target creep’s damaged body parts function and increase the hits counter.
      * Requires the HEAL body part.
      * The target has to be at an adjacent square to the creep.
      */
-    heal(target: AnyCreep): CreepActionReturnCode;
+    heal(target: Creep): CreepHealResult;
     /**
      * Heal another creep at a distance.
      * It will restore the target creep’s damaged body parts function and increase the hits counter.
      * Requires the HEAL body part.
      * The target has to be within 3 squares range of the creep.
      */
-    rangedHeal(target: AnyCreep): CreepActionReturnCode;
+    rangedHeal(target: Creep): CreepRangedHealResult;
 
     /**
      * Harvest energy from the source or resource from minerals or deposits.
@@ -105,9 +109,7 @@ declare module "game/prototypes" {
      * The target has to be at an adjacent square to the creep.
      * @param target The source object to be harvested.
      */
-    harvest(
-      target: Source /* | Mineral | Deposit*/
-    ): CreepActionReturnCode | ERR_NOT_FOUND | ERR_NOT_ENOUGH_RESOURCES;
+    harvest(target: Source /* | Mineral | Deposit*/): CreepHarvestResult;
 
     /**
      * Allow another creep to follow this creep. The fatigue generated for the target's move will be added to the creep instead of the target.
@@ -115,15 +117,7 @@ declare module "game/prototypes" {
      * Requires the MOVE body part. The target must be adjacent to the creep. The creep must move elsewhere, and the target must move towards the creep.
      * @param target The target creep to be pulled.
      */
-    pull(
-      target: Creep
-    ):
-      | OK
-      | ERR_NOT_OWNER
-      | ERR_BUSY
-      | ERR_INVALID_TARGET
-      | ERR_NOT_IN_RANGE
-      | ERR_NO_BODYPART;
+    pull(target: Creep): CreepPullResult;
 
     /**
      * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
@@ -132,10 +126,10 @@ declare module "game/prototypes" {
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      */
     transfer(
-      target: AnyCreep | Structure | ScoreCollector,
+      target: Creep | Structure | ScoreCollector,
       resourceType: ResourceConstant,
       amount?: number
-    ): ScreepsReturnCode;
+    ): CreepTransferResult;
 
     /**
      * Withdraw resources from a structure, a tombstone or a ruin.
@@ -153,23 +147,20 @@ declare module "game/prototypes" {
       target: Structure /* | Tombstone | Ruin*/,
       resourceType: ResourceConstant,
       amount?: number
-    ): ScreepsReturnCode;
+    ): CreepWithdrawResult;
 
     /**
      * Drop this resource on the ground.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      */
-    drop(
-      resourceType: ResourceConstant,
-      amount?: number
-    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
+    drop(resourceType: ResourceConstant, amount?: number): CreepDropResult;
 
     /**
      * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
      */
-    pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
+    pickup(target: Resource): CreepPickupResult;
 
     /**
      * Build a structure at the target construction site using carried energy.
@@ -180,15 +171,7 @@ declare module "game/prototypes" {
      * @param target The target construction site to be built.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_RCL_NOT_ENOUGH
      */
-    build(
-      target: ConstructionSite
-    ): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES;
-
-    /**
-     * Whether this creep is spawning or not.
-     * This field is undocumented, but very useful.
-     */
-    spawning: boolean;
+    build(target: ConstructionSite): CreepBuildResult;
   }
 
   interface CreepConstructor

--- a/dist/game/prototypes/creep.d.ts
+++ b/dist/game/prototypes/creep.d.ts
@@ -63,9 +63,9 @@ declare module "game/prototypes" {
      * Find the optimal path to the target within the same room and move to it.
      * A shorthand to consequent calls of findPathTo() and move() methods.
      * @param target target can be any object containing x and y properties.
-     * @param opts opts is an optional object containing additional options. See /game/utils::findPath for details.
+     * @param options options is an optional object containing additional options. See findPath for details.
      */
-    moveTo(target: Position, opts?: FindPathOptions): CreepMoveResult;
+    moveTo(target: Position, options?: FindPathOptions): CreepMoveResult;
     /**
      * A ranged attack against another creep or structure. Requires the RANGED_ATTACK body part.
      * The target has to be within 3 squares range of the creep.

--- a/dist/game/prototypes/game-object.d.ts
+++ b/dist/game/prototypes/game-object.d.ts
@@ -58,7 +58,7 @@ declare module "game/prototypes" {
      * @param options.ignore objects which should not be treated as obstacles during the search
      * @returns the path found as an array of objects containing x and y properties
      */
-    findPathTo(pos: Position, opts?: FindPathOptions): Position[];
+    findPathTo(pos: Position, options?: FindPathOptions): Position[];
 
     /**
      * Find all positions from the given positions array within the specified linear range.
@@ -76,14 +76,22 @@ declare module "game/prototypes" {
     findClosestByRange<T extends Position>(positions: T[]): T | null;
 
     /**
-     * Find a position with the shortest path from the given position, or null otherwise.
-     * @param opts object containing additional options:
-     * ignore: array (objects which should be treated as obstacles during the search)
-     * Any options supported by searchPath method
+     * Find a position with the shortest path from this game object
+     * @param positions The positions to search among. An array of GameObject or any objects containing x and y properties
+     * @param options An object containing additional pathfinding flags
+     * @param options.costMatrix Custom navigation cost data
+     * @param options.plainCost Cost for walking on plain positions. The default is 2
+     * @param options.swampCost Cost for walking on swamp positions. The default is 10
+     * @param options.flee Instead of searching for a path to the goals this will search for a path away from the goals. The default is false
+     * @param options.maxOps The maximum allowed pathfinding operations. The default value is 50000
+     * @param options.maxCost The maximum allowed cost of the path returned. The default is Infinity
+     * @param options.heuristicWeight Weight from 1 to 9 to apply to the heuristic in the A* formula F = G + weight * H. The default value is 1.2
+     * @param options.ignore objects which should not be treated as obstacles during the search
+     * @returns the closest object from positions, or null if there was no valid positions
      */
     findClosestByPath<T extends Position>(
       positions: T[],
-      opts?: FindPathOptions
+      options?: FindPathOptions
     ): T | null;
 
     toJSON(): GameObjectJSON;

--- a/dist/game/prototypes/game-object.d.ts
+++ b/dist/game/prototypes/game-object.d.ts
@@ -1,11 +1,25 @@
 declare module "game/prototypes" {
-  import { FindPathOpts, PathStep } from "game/path-finder";
-  export interface RoomObjectJSON {
+  import { FindPathOptions } from "game/path-finder";
+
+  export interface GameObjectJSON {
     id: number;
     x: number;
     y: number;
   }
-  export interface GameObject extends RoomPosition {
+
+  /** Position of object in the room */
+  export interface Position {
+    /** The X coordinate in the room */
+    x: number;
+    /** The Y coordinate in the room */
+    y: number;
+  }
+
+  /**
+   * Basic prototype for game objects.
+   * All objects and classes are inherited from this class
+   */
+  export interface GameObject extends Position {
     /**
      * A unique object identificator.
      * You can use {@link getObjectById} method to retrieve an object instance by its id.
@@ -25,23 +39,41 @@ declare module "game/prototypes" {
 
     /**
      * Get linear range to another position. pos may be any object containing x and y properties.
+     * @param pos The target object. May be GameObject or any object containing x and y properties
+     * @returns a number of squares between two objects
      */
-    getRangeTo(pos: RoomPosition): number;
+    getRangeTo(pos: Position): number;
 
     /**
-     * Returns the path from this object to another position. pos can be any object containing x and y properties. See /game/utils::findPath for details.
+     * Returns the path from this object to another position.
+     * @param pos The target position. May be GameObject or any object containing x and y properties
+     * @param options An object with additional options that are passed to the findPath method
+     * @param options.costMatrix Custom navigation cost data
+     * @param options.plainCost Cost for walking on plain positions. The default is 2
+     * @param options.swampCost Cost for walking on swamp positions. The default is 10
+     * @param options.flee Instead of searching for a path to the goals this will search for a path away from the goals. The default is false
+     * @param options.maxOps The maximum allowed pathfinding operations. The default value is 50000
+     * @param options.maxCost The maximum allowed cost of the path returned. The default is Infinity
+     * @param options.heuristicWeight Weight from 1 to 9 to apply to the heuristic in the A* formula F = G + weight * H. The default value is 1.2
+     * @param options.ignore objects which should not be treated as obstacles during the search
+     * @returns the path found as an array of objects containing x and y properties
      */
-    findPathTo(pos: RoomPosition, opts?: FindPathOpts): PathStep[];
+    findPathTo(pos: Position, opts?: FindPathOptions): Position[];
 
     /**
      * Find all positions from the given positions array within the specified linear range.
+     * @param positions The positions to search. An array of GameObject or any objects containing x and y properties
+     * @param range The range distance
+     * @returns an array with the objects found
      */
-    findInRange<T extends RoomPosition>(positions: T[], range: number): T[];
+    findInRange<T extends Position>(positions: T[], range: number): T[];
 
     /**
      * Find a position with the shortest linear distance from the given position, or null otherwise.
+     * @param positions The positions to search among. An array of GameObject or any objects containing x and y properties
+     * @returns the closest object from positions array
      */
-    findClosestByRange<T extends RoomPosition>(positions: T[]): T | null;
+    findClosestByRange<T extends Position>(positions: T[]): T | null;
 
     /**
      * Find a position with the shortest path from the given position, or null otherwise.
@@ -49,12 +81,12 @@ declare module "game/prototypes" {
      * ignore: array (objects which should be treated as obstacles during the search)
      * Any options supported by searchPath method
      */
-    findClosestByPath<T extends RoomPosition>(
+    findClosestByPath<T extends Position>(
       positions: T[],
-      opts?: FindPathOpts
+      opts?: FindPathOptions
     ): T | null;
 
-    toJSON(): RoomObjectJSON;
+    toJSON(): GameObjectJSON;
   }
 
   interface GameObjectConstructor

--- a/dist/game/prototypes/owned-structure.d.ts
+++ b/dist/game/prototypes/owned-structure.d.ts
@@ -1,7 +1,8 @@
 declare module "game/prototypes" {
   interface OwnedStructureJSON extends StructureJSON {
-    my: boolean | undefined;
+    my?: boolean;
   }
+
   /**
    * The base prototype for a structure that has an owner.
    */
@@ -9,7 +10,6 @@ declare module "game/prototypes" {
     T extends StructureConstant = StructureConstant
   > extends Structure<T> {
     readonly prototype: OwnedStructure;
-
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
@@ -17,5 +17,6 @@ declare module "game/prototypes" {
 
     toJSON(): OwnedStructureJSON;
   }
+
   export const OwnedStructure: _Constructor<OwnedStructure>;
 }

--- a/dist/game/prototypes/prototypes.d.ts
+++ b/dist/game/prototypes/prototypes.d.ts
@@ -4,6 +4,7 @@ declare module "game/prototypes" {
     new (): T;
     (): T;
   }
+
   export interface _ConstructorById<T> extends _Constructor<T> {
     new (id: Id<T>): T;
     (id: Id<T>): T;
@@ -18,15 +19,4 @@ declare module "game/prototypes" {
   }
 
   export type Id<T> = string & Tag.OpaqueTag<T>;
-
-  export interface RoomPosition {
-    /**
-     * X position in the room. Can be undefined if `.exists` is false
-     */
-    x: number /* | undefined;*/;
-    /**
-     * Y position in the room. Can be undefined if `.exists` is false
-     */
-    y: number /* | undefined;*/;
-  }
 }

--- a/dist/game/prototypes/resource.d.ts
+++ b/dist/game/prototypes/resource.d.ts
@@ -1,16 +1,17 @@
 declare module "game/prototypes" {
   import type { ResourceConstant } from "game/constants";
+
+  /** A dropped piece of resource. Dropped resource pile decays for ceil(amount/1000) units per tick */
   export interface Resource extends GameObject {
     readonly prototype: Resource;
+    /**
+     * The amount of dropped resource
+     */
     amount: number;
+    /**
+     * The type of dropped resource (one of RESOURCE_* constants)
+     */
     resourceType: ResourceConstant;
-    // TODO: fix toJSON
-    // toJSON() {
-    //   return Object.assign(super.toJSON(), {
-    //     amount: this.amount,
-    //     resourceType: this.resourceType
-    //   });
-    // }
   }
 
   export const Resource: _Constructor<Resource>;

--- a/dist/game/prototypes/source.d.ts
+++ b/dist/game/prototypes/source.d.ts
@@ -1,16 +1,13 @@
 declare module "game/prototypes" {
+  /** An energy source object. Can be harvested by creeps with a WORK body part */
   export interface Source extends GameObject {
     readonly prototype: Source;
 
+    /** Current amount of energy in the source */
     energy: number;
+
+    /** The maximum amount of energy in the source */
     energyCapacity: number;
-    // TODO: fix toJSON
-    // toJSON() {
-    //   return Object.assign(super.toJSON(), {
-    //     energy: this.energy,
-    //     energyCapacity: this.energyCapacity
-    //   });
-    // }
   }
 
   export const Source: _Constructor<Source>;

--- a/dist/game/prototypes/store.d.ts
+++ b/dist/game/prototypes/store.d.ts
@@ -1,7 +1,7 @@
 declare module "game/prototypes" {
   import { ResourceConstant } from "game/constants";
 
-  interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant> {
+  interface StoreBase {
     /**
      * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
      * @param resource The type of the resource.
@@ -24,8 +24,10 @@ declare module "game/prototypes" {
     getFreeCapacity(resource?: ResourceConstant): number | null;
   }
 
-  export type Store<POSSIBLE_RESOURCES extends ResourceConstant> =
-    StoreBase<POSSIBLE_RESOURCES> & { [P in POSSIBLE_RESOURCES]: number } & {
-      [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0;
-    };
+  /** An object that class contain resources in its cargo */
+  export type Store<POSSIBLE_RESOURCES extends ResourceConstant> = StoreBase & {
+    [P in POSSIBLE_RESOURCES]: number;
+  } & {
+    [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0;
+  };
 }

--- a/dist/game/prototypes/structure-container.d.ts
+++ b/dist/game/prototypes/structure-container.d.ts
@@ -1,7 +1,14 @@
 declare module "game/prototypes" {
   import { ResourceConstant } from "game/constants";
+
   export type STRUCTURE_CONTAINER = "container";
   // export const STRUCTURE_CONTAINER: STRUCTURE_CONTAINER;
+
+  /**
+   * A small container that can be used to store resources.
+   * This is a walkable structure.
+   * All dropped resources automatically goes to the container at the same tile.
+   */
   export interface StructureContainer
     extends OwnedStructure<STRUCTURE_CONTAINER> {
     /**
@@ -9,6 +16,7 @@ declare module "game/prototypes" {
      */
     store: Store<ResourceConstant>;
   }
+
   interface StructureContainerConstructor
     extends _Constructor<StructureContainer>,
       _ConstructorById<StructureContainer> {}

--- a/dist/game/prototypes/structure-extension.d.ts
+++ b/dist/game/prototypes/structure-extension.d.ts
@@ -1,7 +1,10 @@
 declare module "game/prototypes" {
   import { ResourceConstant } from "game/constants";
+
   export type STRUCTURE_EXTENSION = "extension";
   // export const STRUCTURE_EXTENSION: STRUCTURE_EXTENSION;
+
+  /** Contains energy that can be spent on spawning bigger creeps */
   export interface StructureExtension
     extends OwnedStructure<STRUCTURE_EXTENSION> {
     /**
@@ -9,6 +12,7 @@ declare module "game/prototypes" {
      */
     store: Store<ResourceConstant>;
   }
+
   interface StructureExtensionConstructor
     extends _Constructor<StructureExtension>,
       _ConstructorById<StructureExtension> {}

--- a/dist/game/prototypes/structure-rampart.d.ts
+++ b/dist/game/prototypes/structure-rampart.d.ts
@@ -2,6 +2,7 @@ declare module "game/prototypes" {
   export type STRUCTURE_RAMPART = "rampart";
   // export const STRUCTURE_RAMPART: STRUCTURE_RAMPART;
 
+  /** Blocks movement of hostile creeps, and defends your creeps and structures on the same position. */
   export interface StructureRampart extends OwnedStructure<STRUCTURE_RAMPART> {}
 
   interface StructureRampartConstructor

--- a/dist/game/prototypes/structure-road.d.ts
+++ b/dist/game/prototypes/structure-road.d.ts
@@ -1,6 +1,8 @@
 declare module "game/prototypes" {
   export type STRUCTURE_ROAD = "road";
   // export const STRUCTURE_ROAD: STRUCTURE_ROAD;
+
+  /** Decreases movement cost to 1. Using roads allows creating creeps with less MOVE body parts */
   export interface StructureRoad extends Structure<STRUCTURE_ROAD> {
     readonly prototype: StructureRoad;
   }
@@ -8,5 +10,6 @@ declare module "game/prototypes" {
   interface StructureRoadConstructor
     extends _Constructor<StructureRoad>,
       _ConstructorById<StructureRoad> {}
+
   export const StructureRoad: StructureRoadConstructor;
 }

--- a/dist/game/prototypes/structure-spawn.d.ts
+++ b/dist/game/prototypes/structure-spawn.d.ts
@@ -9,6 +9,21 @@ declare module "game/prototypes" {
     ResourceConstant,
   } from "game/constants";
   import { Store } from "game/prototypes";
+
+  /**
+   * The result of the StructureSpawn.spawnCreep method.
+   */
+  export interface SpawnCreepResult {
+    /**
+     * The instance of the Creep being spawned
+     */
+    object?: Creep;
+    /**
+     * The error code
+     */
+    error?: ERR_NOT_OWNER | ERR_INVALID_ARGS | ERR_NOT_ENOUGH_ENERGY | ERR_BUSY;
+  }
+
   /**
    * Details of the creep being spawned currently that can be addressed by the StructureSpawn.spawning property.
    */
@@ -33,6 +48,7 @@ declare module "game/prototypes" {
 
   export type STRUCTURE_SPAWN = "spawn";
   // export const STRUCTURE_SPAWN: STRUCTURE_SPAWN;
+
   export interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
     /**
      * A Store object that contains a cargo of this structure. Spawns can contain only energy.
@@ -40,12 +56,10 @@ declare module "game/prototypes" {
     store: Store<ResourceConstant>;
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and extensions in the room.
-     * @returns A creep on success or an errorcode on failure
+     * @param body An array describing the new creep's body
+     * @returns A creep on success or an error code on failure
      */
-    spawnCreep(body: BodyPartConstant[]): {
-      object?: Creep;
-      error?: ERR_BUSY | ERR_INVALID_ARGS | ERR_NOT_ENOUGH_ENERGY;
-    };
+    spawnCreep(body: BodyPartConstant[]): SpawnCreepResult;
     /**
      * If the spawn is in process of spawning a new creep, this object will contain a Spawning object, or undefined otherwise.
      * CAUION: The document says "or null", but actually it returns undefined when not spawning.

--- a/dist/game/prototypes/structure-tower.d.ts
+++ b/dist/game/prototypes/structure-tower.d.ts
@@ -1,30 +1,20 @@
 declare module "game/prototypes" {
   import {
-    AnyCreep,
     ResourceConstant,
-    ScreepsReturnCode,
+    TowerAttackResult,
+    TowerHealResult,
   } from "game/constants";
   import { Store } from "game/prototypes";
+
   export type STRUCTURE_TOWER = "tower";
   // export const STRUCTURE_TOWER: STRUCTURE_TOWER;
+
+  /** Remotely attacks game objects or heals creeps within its range */
   export interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
-    /**
-     * The current amount of hit points of the tower.
-     */
-    hits: number;
-    /**
-     * The maximum amount of hit points of the tower.
-     */
-    hitsMax: number;
-    /**
-     * Returns true for your tower, false for a hostile tower, undefined for a neutral tower.
-     */
-    my: boolean;
     /**
      * A Store object that contains a cargo of this structure. Towers can contain only energy.
      */
     store: Store<ResourceConstant>;
-
     /**
      * 10-ticks cooldown for towers (Tower.cooldown). Exception: towers in CTF can shoot each tick.
      */
@@ -34,21 +24,13 @@ declare module "game/prototypes" {
      * The target has to be within 50 squares range of the tower.
      * Attack effectiveness	600 hits at range ≤5 to 150 hits at range ≥20
      */
-    attack(target: AnyCreep | Structure): ScreepsReturnCode;
+    attack(target: Creep | Structure): TowerAttackResult;
     /**
      * Remotely heal any creep.
      * The target has to be within 50 squares range of the tower.
      * Heal effectiveness	400 hits at range ≤5 to 100 hits at range ≥20
      */
-    heal(target: AnyCreep): ScreepsReturnCode;
-
-    // // /**
-    // //  * Remotely heal any creep.
-    // //  * The target has to be within 50 squares range of the tower.
-    // //  * Repair effectiveness	800 hits at range ≤5 to 200 hits at range ≥20
-    // //  * @param target
-    // //  */
-    // // repair(target: Structure): ScreepsReturnCode;
+    heal(target: Creep): TowerHealResult;
   }
 
   interface StructureTowerConstructor

--- a/dist/game/prototypes/structure-wall.d.ts
+++ b/dist/game/prototypes/structure-wall.d.ts
@@ -1,6 +1,8 @@
 declare module "game/prototypes" {
   export type STRUCTURE_WALL = "constructedWall";
   // export const STRUCTURE_WALL: STRUCTURE_WALL;
+
+  /** Blocks movement of all creeps */
   export interface StructureWall extends Structure<STRUCTURE_WALL> {
     readonly prototype: StructureWall;
   }
@@ -8,5 +10,6 @@ declare module "game/prototypes" {
   interface StructureWallConstructor
     extends _Constructor<StructureWall>,
       _ConstructorById<StructureWall> {}
+
   export const StructureWall: StructureWallConstructor;
 }

--- a/dist/game/prototypes/structure.d.ts
+++ b/dist/game/prototypes/structure.d.ts
@@ -9,10 +9,12 @@ declare module "game/prototypes" {
     | STRUCTURE_ROAD
     | STRUCTURE_EXTENSION;
 
-  export interface StructureJSON extends RoomObjectJSON {
+  export interface StructureJSON extends GameObjectJSON {
     hits: number;
     hitsMax: number;
   }
+
+  /** The base prototype object of all structures. */
   export interface Structure<T extends StructureConstant = StructureConstant>
     extends GameObject {
     readonly prototype: Structure;

--- a/dist/game/utils.d.ts
+++ b/dist/game/utils.d.ts
@@ -149,7 +149,7 @@ declare module "game/utils" {
   export function findClosestByPath<T extends Position>(
     fromPos: Position,
     positions: T[],
-    opts?: FindPathOptions
+    options?: FindPathOptions
   ): T;
 
   /**

--- a/dist/game/utils.d.ts
+++ b/dist/game/utils.d.ts
@@ -6,103 +6,150 @@ declare module "game/utils" {
     ERR_FULL,
     ERR_INVALID_ARGS,
     ERR_INVALID_TARGET,
+    TERRAIN_PLAIN,
     TERRAIN_SWAMP,
     TERRAIN_WALL,
+    TerrainConstant,
   } from "game/constants";
   import {
     ConstructionSite,
     GameObject,
     Id,
-    RoomPosition,
+    Position,
     _Constructor,
   } from "game/prototypes";
-  import { FindPathOpts, PathStep } from "game/path-finder";
+  import { FindPathOptions } from "game/path-finder";
+
+  export interface HeapStatistics {
+    total_heap_size: number;
+    total_heap_size_executable: number;
+    total_physical_size: number;
+    total_available_size: number;
+    used_heap_size: number;
+    heap_size_limit: number;
+    malloced_memory: number;
+    peak_malloced_memory: number;
+    does_zap_garbage: 0 | 1;
+    number_of_native_contexts: number;
+    number_of_detached_contexts: number;
+    externally_allocated_size: number;
+  }
 
   /**
    * Get count of game ticks passed since the start of the game
    */
   export function getTicks(): number;
+
   /**
    * Get an object with the specified unique ID.
+   * @param id The id property of the needed object. See GameObject prototype.
    */
   export function getObjectById<T>(id: Id<T>): T | null;
+
   /**
    * Get all objects in the game.
    */
   export function getObjects(): GameObject[];
+
   /**
    * Get all objects in the game with the specified prototype, for example, all creeps
+   * @param prototype A prototype that extends GameObject
+   * @returns Array of objects with the specified prototype
    */
   export function getObjectsByPrototype<T>(prototype: _Constructor<T>): T[];
+
   /**
    * Use this method to get heap statistics for your virtual machine
    */
   export function getHeapStatistics(): HeapStatistics;
+
   /**
    * Get linear direction by differences of x and y
    */
   export function getDirection(dx: number, dy: number): DirectionConstant;
 
   /**
-   * Find an optimal path between fromPos and toPos. Unlike searchPath,
-   * findPath avoid all obstacles by default (unless costMatrix is specified).
-   * @param opts object containing additional options:
-   * ignore: array (objects which should be treated as obstacles during the search)
-   * Any options supported by searchPath method
+   * Find an optimal path between fromPos and toPos.
+   * Unlike {@link searchPath}, findPath avoid all obstacles by default (unless costMatrix is specified).
+   * @param fromPos The start position. May be GameObject or any object containing x and y properties.
+   * @param toPos The target position. May be GameObject or any object containing x and y properties.
+   * @param options An object containing additional pathfinding flags
+   * @param options.costMatrix Custom navigation cost data
+   * @param options.plainCost Cost for walking on plain positions. The default is 2
+   * @param options.swampCost Cost for walking on swamp positions. The default is 10
+   * @param options.flee Instead of searching for a path to the goals this will search for a path away from the goals. The default is false
+   * @param options.maxOps The maximum allowed pathfinding operations. The default value is 50000
+   * @param options.maxCost The maximum allowed cost of the path returned. The default is Infinity
+   * @param options.heuristicWeight Weight from 1 to 9 to apply to the heuristic in the A* formula F = G + weight * H. The default value is 1.2
+   * @param options.ignore objects which should not be treated as obstacles during the search
+   * @returns the path found as an array of objects containing x and y properties
    */
   export function findPath(
-    fromPos: RoomPosition,
-    toPos: RoomPosition,
-    opts?: FindPathOpts
-  ): PathStep[];
+    fromPos: Position,
+    toPos: Position,
+    options?: FindPathOptions
+  ): Position[];
 
   /**
    * Get linear range between two objects. a and b may be any object containing x and y properties.
    * @deprecated alias for getRange
    */
-  export function getDistance(a: RoomPosition, b: RoomPosition): number;
+  export function getDistance(a: Position, b: Position): number;
 
   /**
    * Get linear range between two objects. a and b may be any object containing x and y properties.
+   * @param a The first of two objects. May be GameObject or any object containing x and y properties.
+   * @param b The second of two objects. May be GameObject or any object containing x and y properties.
+   * @returns a number of squares between two objects
    */
-  export function getRange(a: RoomPosition, b: RoomPosition): number;
+  export function getRange(a: Position, b: Position): number;
 
   /**
    * Get an integer representation of the terrain at the given position.
-   * Returns TERRAIN_WALL, TERRAIN_SWAMP, or 0.
+   * Returns TERRAIN_WALL, TERRAIN_SWAMP, or TERRAIN_PLAIN.
    * @param pos pos should be an object containing x and y properties
    */
-  export function getTerrainAt(
-    pos: RoomPosition
-  ): TERRAIN_WALL | TERRAIN_SWAMP | 0;
+  export function getTerrainAt(pos: Position): TerrainConstant;
 
   /**
    * Find all positions from the given positions array within the specified linear range.
    */
-  export function findInRange<T extends RoomPosition>(
-    fromPos: RoomPosition,
+  export function findInRange<T extends Position>(
+    fromPos: Position,
     positions: T[],
     range: number
   ): T[];
 
   /**
-   * Find a position with the shortest linear distance from the given position, or null otherwise.
+   * Find a position with the shortest linear distance from the given position
+   * @param fromPos The position to search from. May be GameObject or any object containing x and y properties
+   * @param positions The positions to search among. An array of GameObject or any objects containing x and y properties
+   * @returns the closest object from {@link positions}
    */
-  export function findClosestByRange<T extends RoomPosition>(
-    fromPos: RoomPosition,
+  export function findClosestByRange<T extends Position>(
+    fromPos: Position,
     positions: T[]
   ): T;
 
   /**
-   * Find a position with the shortest path from the given position, or null otherwise.
-   * @param opts object containing additional options:
-   * ignore: array (objects which should be treated as obstacles during the search)
-   * Any options supported by searchPath method
+   * Find a position with the shortest path from the given position
+   * @param fromPos The position to search from. May be GameObject or any object containing x and y properties
+   * @param positions The positions to search among. An array of GameObject or any objects containing x and y properties
+   * @param options An object containing additional pathfinding flags
+   * @param options.costMatrix Custom navigation cost data
+   * @param options.plainCost Cost for walking on plain positions. The default is 2
+   * @param options.swampCost Cost for walking on swamp positions. The default is 10
+   * @param options.flee Instead of searching for a path to the goals this will search for a path away from the goals. The default is false
+   * @param options.maxOps The maximum allowed pathfinding operations. The default value is 50000
+   * @param options.maxCost The maximum allowed cost of the path returned. The default is Infinity
+   * @param options.heuristicWeight Weight from 1 to 9 to apply to the heuristic in the A* formula F = G + weight * H. The default value is 1.2
+   * @param options.ignore objects which should not be treated as obstacles during the search
+   * @returns the closest object from {@link positions}, or null if there was no valid positions
    */
-  export function findClosestByPath<T extends RoomPosition>(
-    fromPos: RoomPosition,
+  export function findClosestByPath<T extends Position>(
+    fromPos: Position,
     positions: T[],
-    opts?: FindPathOpts
+    opts?: FindPathOptions
   ): T;
 
   /**
@@ -111,7 +158,7 @@ declare module "game/utils" {
    * @param y The Y position.
    * @param structurePrototype One of the following constants: StuctureExtension, StructureTower
    * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
-   * @deprecated use the overload with a RoomPosition object
+   * @deprecated use the overload with a Position object
    */
   export function createConstructionSite<T extends BuildableStructure>(
     x: number,
@@ -129,27 +176,15 @@ declare module "game/utils" {
    * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
    */
   export function createConstructionSite(
-    pos: RoomPosition,
+    pos: Position,
     structureType: _Constructor<BuildableStructure>
   ): {
     object?: ConstructionSite;
     error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
   };
+
   /**
    * Get CPU wall time elapsed in the current tick in nanoseconds.
    */
   export function getCpuTime(): number;
-
-  export interface HeapStatistics {
-    total_heap_size: number;
-    total_heap_size_executable: number;
-    total_physical_size: number;
-    total_available_size: number;
-    used_heap_size: number;
-    heap_size_limit: number;
-    malloced_memory: number;
-    peak_malloced_memory: number;
-    does_zap_garbage: 0 | 1;
-    externally_allocated_size: number;
-  }
 }

--- a/dist/game/visual.d.ts
+++ b/dist/game/visual.d.ts
@@ -1,5 +1,97 @@
 declare module "game/visual" {
-  import { RoomPosition, _Constructor } from "game/prototypes";
+  import { Position, _Constructor } from "game/prototypes";
+
+  export type LineStyle = "dashed" | "dotted";
+
+  export type TextAlign = "center" | "left" | "right";
+
+  export interface LineVisualStyle {
+    /**
+     * Line width, default is 0.1.
+     */
+    width?: number;
+    /**
+     * Line color in any web format, default is #ffffff(white).
+     */
+    color?: string;
+    /**
+     * Opacity value, default is 0.5.
+     */
+    opacity?: number;
+    /**
+     * Either undefined (solid line), dashed, or dotted.Default is undefined.
+     */
+    lineStyle?: LineStyle;
+  }
+
+  export interface PolyVisualStyle {
+    /**
+     * Fill color in any web format, default is undefined (no fill).
+     */
+    fill?: string;
+    /**
+     * Opacity value, default is 0.5.
+     */
+    opacity?: number;
+    /**
+     * Stroke color in any web format, default is #ffffff (white).
+     */
+    stroke?: string;
+    /**
+     * Stroke line width, default is 0.1.
+     */
+    strokeWidth?: number;
+    /**
+     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     */
+    lineStyle?: LineStyle;
+  }
+
+  export interface RectVisualStyle extends PolyVisualStyle {}
+
+  export interface CircleVisualStyle extends PolyVisualStyle {
+    /**
+     * Circle radius, default is 0.15.
+     */
+    radius?: number;
+  }
+
+  export interface TextVisualStyle {
+    /**
+     * Font color in any web format, default is #ffffff(white).
+     */
+    color?: string;
+    /**
+     * Either a number or a string in one of the following forms:
+     * "0.7" (relative size in game coordinates),
+     * "20px" (absolute size in pixels),
+     * "0.7 serif", or
+     * "bold italic 1.5 Times New Roman"
+     */
+    font?: number | string;
+    /**
+     * Stroke color in any web format, default is undefined (no stroke).
+     */
+    stroke?: string;
+    /**
+     * Stroke width, default is 0.15.
+     */
+    strokeWidth?: number;
+    /**
+     * Background color in any web format, default is undefined (no background).When background is enabled, text vertical align is set to middle (default is baseline).
+     */
+    backgroundColor?: string;
+
+    /**
+     * Background rectangle padding, default is 0.3.
+     */
+    backgroundPadding?: number;
+    align?: "center" | "left" | "right";
+    /**
+     * Opacity value, default is 1.0.
+     */
+    opacity?: number;
+  }
 
   /**
    * Visuals provide a way to show various visual debug info in the game.
@@ -19,16 +111,17 @@ declare module "game/visual" {
 
     /**
      * Draw a line.
-     * @param pos1 The start position object. May be GameObject or any object containing x and y properties.
-     * @param pos2 The finish position object. May be GameObject or any object containing x and y properties.
-     * @param style
-     * 	An object with the following properties:
-     * - width (number) Line width, default is 0.1.
-     * - color (string) Line color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - opacity (number) Opacity value, default is 0.5.
-     * - lineStyle (string) Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * @param pos1 The start position object. May be {@link GameObject} or any object containing x and y properties.
+     * @param pos2 The finish position object. May be {@link GameObject} or any object containing x and y properties.
+     * @param style An object with additional options
+     * @param style.width Line width, default is 0.1
+     * @param style.color Line color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.opacity Opacity value, default is 0.5
+     * @param style.lineStyle Either undefined (solid line), dashed, or dotted. Default is undefined
+     * @returns the {@link Visual} object itself, so that you can chain calls.
      */
-    line(pos1: RoomPosition, pos2: RoomPosition, style?: LineStyle): Visual;
+    line(pos1: Position, pos2: Position, style?: LineVisualStyle): Visual;
+
     /**
      * Draw a circle.
      * @param pos The position object of the center. May be GameObject or any object containing x and y properties.
@@ -40,55 +133,53 @@ declare module "game/visual" {
      * - strokeWidth (number) Stroke line width, default is 0.1.
      * - lineStyle (string) Either undefined (solid line), dashed, or dotted. Default is undefined.
      */
-    circle(pos: RoomPosition, style?: CircleStyle): Visual;
+    circle(pos: Position, style?: CircleVisualStyle): Visual;
 
     /**
      * Draw a rectangle.
-     * @param topLeftPos The position object of the top-left corner. May be GameObject or any object containing x and y properties.
-     * @param width The width of the rectangle.
-     * @param height The height of the rectangle.
-     * @param style An object with the following properties:
-     * - radius (number) Circle radius, default is 0.15.
-     * - fill (string) Fill color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - opacity (number) Opacity value, default is 0.5.
-     * - stroke (string) Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - strokeWidth (number) Stroke line width, default is 0.1.
-     * - lineStyle (string) Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * @param pos The position object of the top-left corner. May be {@link GameObject} or any object containing x and y properties.
+     * @param w The width of the rectangle.
+     * @param h The height of the rectangle.
+     * @param style An object with additional options
+     * @param style.fill Fill color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.opacity Opacity value, default is 0.5
+     * @param style.stroke Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.strokeWidth Stroke line width, default is 0.1
+     * @param style.lineStyle Either undefined (solid line), dashed, or dotted. Default is undefined
+     * @returns the {@link Visual} object itself, so that you can chain calls.
      */
-    rect(
-      topLeftPos: RoomPosition,
-      width: number,
-      height: number,
-      style?: PolyStyle
-    ): Visual;
+    rect(pos: Position, w: number, h: number, style?: RectVisualStyle): Visual;
+
     /**
      * Draw a polyline.
-     * @param points 	An array of points. Every item may be GameObject or any object containing x and y properties.
-     * @param style An object with the following properties:
-     * - fill (string) Fill color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - opacity (number) Opacity value, default is 0.5.
-     * - stroke (string) Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - strokeWidth (number) Stroke line width, default is 0.1.
-     * - lineStyle (string) Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * @param points An array of points. Every item may be {@link GameObject} or any object containing x and y properties.
+     * @param style An object with additional options
+     * @param style.fill Fill color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.opacity Opacity value, default is 0.5
+     * @param style.stroke Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.strokeWidth Stroke line width, default is 0.1
+     * @param style.lineStyle Either undefined (solid line), dashed, or dotted. Default is undefined
+     * @returns the {@link Visual} object itself, so that you can chain calls.
      */
-    poly(points: RoomPosition[], style?: PolyStyle): Visual;
+    poly(points: Position[], style?: PolyVisualStyle): Visual;
+
     /**
      * Draw a text label. You can use any valid Unicode characters, including emoji.
      * @param text The text message.
-     * @param pos The position object of the label baseline. May be GameObject or any object containing x and y properties.
-     * @param style An object with the following properties:
-     * - color (string) Font color in the following format: #ffffff (hex triplet). Default is #ffffff.
-     * - font (number|string) Either a number or a string in one of the following forms: "0.7" (relative size in game coordinates)
-     * , "20px" (absolute size in pixels), "0.7 serif", or "bold italic 1.5 Times New Roman"
-     * - stroke (string) Stroke color in the following format: #ffffff (hex triplet). default is undefined (no stroke).
-     * - strokeWidth (number) Stroke line width, default is 0.15.
-     * - backgroundColor (string) Background color in the following format: #ffffff (hex triplet).
-     * Default is undefined (no background). When background is enabled, text vertical align is set to middle (default is baseline).
-     * - backgroundPadding (number) Background rectangle padding, default is 0.3.
-     * - aling (string) Text align, either center, left, or right. Default is center.
-     * - opacity (number) Opacity value, default is 1.
+     * @param pos The position object of the label baseline. May be {@link GameObject} or any object containing x and y properties.
+     * @param style An object with additional options
+     * @param style.align Text align, either center, left, or right. Default is center.
+     * @param style.backgroundColor Background color in the following format: #ffffff (hex triplet). Default is undefined (no background)
+     * @param style.backgroundPadding Background rectangle padding, default is 0.3
+     * @param style.color Font color in the following format: #ffffff (hex triplet). Default is #ffffff
+     * @param style.font Either a number or a string in one of the following forms: "0.7", "20px", "0.7 serif", or "bold italic 1.5 Times New Roman"
+     * @param style.opacity Opacity value, default is 1
+     * @param style.stroke Stroke color in the following format: #ffffff (hex triplet). default is undefined (no stroke)
+     * @param style.strokeWidth Stroke line width, default is 0.15
+     * @returns the {@link Visual} object itself, so that you can chain calls.
      */
-    text(text: string, pos: RoomPosition, style?: TextStyle): Visual;
+    text(text: string, pos: Position, style?: TextVisualStyle): Visual;
+
     /**
      * Remove all visuals from the object.
      */
@@ -110,90 +201,4 @@ declare module "game/visual" {
   }
 
   export const Visual: VisualConstructor;
-}
-
-interface LineStyle {
-  /**
-   * Line width, default is 0.1.
-   */
-  width?: number;
-  /**
-   * Line color in any web format, default is #ffffff(white).
-   */
-  color?: string;
-  /**
-   * Opacity value, default is 0.5.
-   */
-  opacity?: number;
-  /**
-   * Either undefined (solid line), dashed, or dotted.Default is undefined.
-   */
-  lineStyle?: "dashed" | "dotted" | undefined;
-}
-
-interface PolyStyle {
-  /**
-   * Fill color in any web format, default is undefined (no fill).
-   */
-  fill?: string | undefined;
-  /**
-   * Opacity value, default is 0.5.
-   */
-  opacity?: number;
-  /**
-   * Stroke color in any web format, default is #ffffff (white).
-   */
-  stroke?: string;
-  /**
-   * Stroke line width, default is 0.1.
-   */
-  strokeWidth?: number;
-  /**
-   * Either undefined (solid line), dashed, or dotted. Default is undefined.
-   */
-  lineStyle?: "dashed" | "dotted" | "solid" | undefined;
-}
-
-interface CircleStyle extends PolyStyle {
-  /**
-   * Circle radius, default is 0.15.
-   */
-  radius?: number;
-}
-
-interface TextStyle {
-  /**
-   * Font color in any web format, default is #ffffff(white).
-   */
-  color?: string;
-  /**
-   * Either a number or a string in one of the following forms:
-   * 0.7 - relative size in game coordinates
-   * 20px - absolute size in pixels
-   * 0.7 serif
-   * bold italic 1.5 Times New Roman
-   */
-  font?: number | string;
-  /**
-   * Stroke color in any web format, default is undefined (no stroke).
-   */
-  stroke?: string | undefined;
-  /**
-   * Stroke width, default is 0.15.
-   */
-  strokeWidth?: number;
-  /**
-   * Background color in any web format, default is undefined (no background).When background is enabled, text vertical align is set to middle (default is baseline).
-   */
-  backgroundColor?: string | undefined;
-
-  /**
-   * Background rectangle padding, default is 0.3.
-   */
-  backgroundPadding?: number;
-  align?: "center" | "left" | "right";
-  /**
-   * Opacity value, default is 1.0.
-   */
-  opacity?: number;
 }

--- a/dist/test/screeps-arena-tests.ts
+++ b/dist/test/screeps-arena-tests.ts
@@ -102,14 +102,14 @@ export function loop(): void {
     );
 
     const findInRangeResult = myTower.findInRange(enemyCreeps, 1); // $ExpectType Creep[]
-    const findPathToResult = myTower.findPathTo(findInRangeResult[0]); // $ExpectType PathStep[]
+    const findPathToResult = myTower.findPathTo(findInRangeResult[0]); // $ExpectType Position[]
     // TODO: findPathTo with options
     const findClosestByPathResult = myTower.findClosestByPath(enemyCreeps); // $ExpectType Creep | null
     // TODO: findClosestByPath with options
 
     // testing utils
     const utilsFindInRangeResult = findInRange(myTower, enemyCreeps, 1); // $ExpectType Creep[]
-    const utilsFindPathToResult = findPath(myTower, utilsFindInRangeResult[0]); // $ExpectType PathStep[]
+    const utilsFindPathToResult = findPath(myTower, utilsFindInRangeResult[0]); // $ExpectType Position[]
     // TODO: findPathTo with options
     // $ExpectType Creep
     const utilsFindClosestByPathResult = findClosestByPath(


### PR DESCRIPTION
Breaking changes:
- Renamed `RoomPosition` to `Position`
- Renamed `FindPathOpts` to `FindPathOptions`
- Removed `MoveToOpts` (use `FindPathOptions` instead)

Other changes:
- Lots of small changes to be more consistent with official types