### PR TITLE
Fix advanced arena imports

### DIFF
--- a/dist/arena/index.d.ts
+++ b/dist/arena/index.d.ts
@@ -1,8 +1,6 @@
 /// <reference path="season_beta/capture_the_flag/basic/prototypes/index.d.ts" />
+/// <reference path="season_beta/capture_the_flag/advanced/prototypes/index.d.ts" />
 /// <reference path="season_beta/collect_and_control/basic/prototypes/index.d.ts" />
+/// <reference path="season_beta/collect_and_control/advanced/prototypes/index.d.ts" />
 /// <reference path="season_beta/collect_and_control/basic/constants/index.d.ts" />
 /// <reference path="season_beta/collect_and_control/advanced/constants/index.d.ts" />
-
-declare module "arena" {
-  export {};
-}

--- a/dist/arena/season_beta/capture_the_flag/advanced/prototypes/body-part.d.ts
+++ b/dist/arena/season_beta/capture_the_flag/advanced/prototypes/body-part.d.ts
@@ -1,0 +1,20 @@
+declare module "arena/season_beta/capture_the_flag/advanced/prototypes" {
+  import { GameObject, _Constructor, _ConstructorById } from "game/prototypes";
+  import { BodyPartConstant } from "game/constants";
+
+  export interface BodyPart extends GameObject {
+    readonly prototype: BodyPart;
+    /**
+     * The type of the body part.
+     */
+    type: BodyPartConstant;
+    /**
+     * The number of ticks until this item disappears.
+     */
+    ticksToDecay: number;
+  }
+  interface BodyPartConstructor
+    extends _Constructor<BodyPart>,
+      _ConstructorById<BodyPart> {}
+  export const BodyPart: BodyPartConstructor;
+}

--- a/dist/arena/season_beta/capture_the_flag/advanced/prototypes/flag.d.ts
+++ b/dist/arena/season_beta/capture_the_flag/advanced/prototypes/flag.d.ts
@@ -1,0 +1,16 @@
+declare module "arena/season_beta/capture_the_flag/advanced/prototypes" {
+  import { GameObject, _Constructor, _ConstructorById } from "game/prototypes";
+  export interface Flag extends GameObject {
+    readonly prototype: Flag;
+    /**
+     * Equals to true or false if the flag is owned.
+     * Returns undefined if it is neutral.
+     */
+    my?: boolean;
+  }
+
+  interface FlagConstructor
+    extends _Constructor<Flag>,
+      _ConstructorById<Flag> {}
+  export const Flag: FlagConstructor;
+}

--- a/dist/arena/season_beta/capture_the_flag/advanced/prototypes/index.d.ts
+++ b/dist/arena/season_beta/capture_the_flag/advanced/prototypes/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="flag.d.ts" />
+/// <reference path="body-part.d.ts" />

--- a/dist/arena/season_beta/collect_and_control/advanced/prototypes/area-effect.d.ts
+++ b/dist/arena/season_beta/collect_and_control/advanced/prototypes/area-effect.d.ts
@@ -1,0 +1,15 @@
+declare module "arena/season_beta/collect_and_control/advanced/prototypes" {
+  import { GameObject, _Constructor } from "game/prototypes";
+  export interface AreaEffect extends GameObject {
+    /**
+     * The type of the effect this has on creep. "freeze" or "damage".
+     */
+    effect: string;
+    /**
+     * The amount of game ticks when this effect will disappear. (undocumented)
+     */
+    ticksToDecay: number | undefined;
+  }
+
+  export const AreaEffect: _Constructor<AreaEffect>;
+}

--- a/dist/arena/season_beta/collect_and_control/advanced/prototypes/index.d.ts
+++ b/dist/arena/season_beta/collect_and_control/advanced/prototypes/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="score-collector.d.ts" />
+/// <reference path="area-effect.d.ts" />

--- a/dist/arena/season_beta/collect_and_control/advanced/prototypes/score-collector.d.ts
+++ b/dist/arena/season_beta/collect_and_control/advanced/prototypes/score-collector.d.ts
@@ -1,0 +1,23 @@
+declare module "arena/season_beta/collect_and_control/advanced/prototypes" {
+  import { GameObject, _Constructor } from "game/prototypes";
+  export interface ScoreCollector extends GameObject {
+    /**
+     * The type of the resource this collector accepts.
+     */
+    resourceType: string;
+    /**
+     * Whether you have control over this collector.
+     */
+    my: boolean;
+    /**
+     * Current collected score number of the owner player.
+     */
+    score: number;
+    /**
+     * Total number of score needed to win instantly.
+     */
+    scoreTotal: number;
+  }
+
+  export const ScoreCollector: _Constructor<ScoreCollector>;
+}

--- a/dist/game/utils.d.ts
+++ b/dist/game/utils.d.ts
@@ -20,6 +20,11 @@ declare module "game/utils" {
   } from "game/prototypes";
   import { FindPathOptions } from "game/path-finder";
 
+  export interface CreateConstructionSiteResult<T extends BuildableStructure> {
+    object?: ConstructionSite<T>;
+    error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
+  }
+
   export interface HeapStatistics {
     total_heap_size: number;
     total_heap_size_executable: number;
@@ -164,10 +169,7 @@ declare module "game/utils" {
     x: number,
     y: number,
     structureType: _Constructor<T>
-  ): {
-    object?: ConstructionSite<T>;
-    error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
-  };
+  ): CreateConstructionSiteResult<T>;
 
   /**
    * Create new ConstructionSite at the specified location.
@@ -178,10 +180,7 @@ declare module "game/utils" {
   export function createConstructionSite(
     pos: Position,
     structureType: _Constructor<BuildableStructure>
-  ): {
-    object?: ConstructionSite;
-    error?: ERR_INVALID_ARGS | ERR_INVALID_TARGET | ERR_FULL;
-  };
+  ): CreateConstructionSiteResult<BuildableStructure>;
 
   /**
    * Get CPU wall time elapsed in the current tick in nanoseconds.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,7 @@
 // Project: https://github.com/screepers/typed-screeps-arena
 // Definitions by: thmsn <https://github.com/thmsndk>
 //                 Skyler Kehren <https://github.com/pyrodogg>
+//                 admon <https://github.com/admon84>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 


### PR DESCRIPTION
This change makes it so you can import prototypes from `arena/season_beta/capture_the_flag/advanced/prototypes` and `arena/season_beta/collect_and_control/advanced/prototypes` for advanced arena bots.