### PR TITLE
add undocumented parameter `range` to FindPathOptions

### DIFF
--- a/dist/game/path-finder.d.ts
+++ b/dist/game/path-finder.d.ts
@@ -90,5 +90,9 @@ declare module "game/path-finder" {
      * An array of the room's objects which should be treated as obstacles during the search
      */
     ignore?: GameObject[];
+    /**
+     * The range to search for the goal. The default is 0. not documented but accepted
+     */
+    range?: number;
   }
 }


### PR DESCRIPTION
undocumented but usefule `range` parameter.

```typescript
import { findPath } from 'game/utils'

export function loop() {
  const path1 = findPath({ x: 5, y: 10 }, { x: 10, y: 10 })
  console.log(`path1.length: ${path1.length}`)
  for (let idx = 0; idx < path1.length; idx++) {
    const pos = path1[idx]
    console.log(`path1[${idx}]: ${pos.x}, ${pos.y}`)
  }

  const path2 = findPath({ x: 5, y: 10 }, { x: 10, y: 10 }, { range: 3 })
  console.log(`path2.length: ${path2.length}`)
  for (let idx = 0; idx < path2.length; idx++) {
    const pos = path2[idx]
    console.log(`path2[${idx}]: ${pos.x}, ${pos.y}`)
  }
}
```

shows

```
path1.length: 5
path1[0]: 6, 10
path1[1]: 7, 10
path1[2]: 8, 10
path1[3]: 9, 9
path1[4]: 10, 10
path2.length: 2
path2[0]: 6, 10
path2[1]: 7, 10
path1.length: 5
path1[0]: 6, 10
path1[1]: 7, 10
path1[2]: 8, 10
path1[3]: 9, 9
path1[4]: 10, 10
path2.length: 2
path2[0]: 6, 10
path2[1]: 7, 10
```

so, it works.